### PR TITLE
Incremented version number to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bplist-creator",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Binary Mac OS X Plist (property list) creator.",
   "main": "bplistCreator.js",
   "scripts": {


### PR DESCRIPTION
Version number wasn't incremented when support for `data` was added and have some code that requires `data`.

Incrementing version number to allow dependencies to work correctly.
