### PR TITLE
real: support for forcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ var buffer = bplist({
 });
 ```
 
+## Real/Double/Float handling
+
+Javascript don't have different types for `1` and `1.0`. This package
+will automatically store numbers as the appropriate type, but can't
+detect floats that is also integers.
+
+If you need to force a value to be written with the `real` type pass
+an instance of `Real`.
+
+```javascript
+var buffer = bplist({
+  backgroundRed: new bplist.Real(1),
+  backgroundGreen: new bplist.Real(0),
+  backgroundBlue: new bplist.Real(0)
+});
+```
+
+In `xml` the corresponding tags is `<integer>` and `<real>`.
+
 ## License
 
 (The MIT License)

--- a/bplistCreator.js
+++ b/bplistCreator.js
@@ -6,6 +6,10 @@ var streamBuffers = require("stream-buffers");
 
 var debug = false;
 
+function Real(value) {
+  this.value = value;
+}
+
 module.exports = function(dicts) {
   var buffer = new streamBuffers.WritableStreamBuffer();
   buffer.write(new Buffer("bplist00"));
@@ -297,6 +301,13 @@ function toEntries(dicts) {
         value: dicts
       }
     ];
+  } else if (dicts instanceof Real) {
+    return [
+      {
+        type: 'double',
+        value: dicts.value
+      }
+    ];
   } else if (typeof(dicts) === 'object') {
     return toEntriesObject(dicts);
   } else if (typeof(dicts) === 'string') {
@@ -389,3 +400,5 @@ function computeIdSizeInBytes(numberOfIds) {
   }
   return 4;
 }
+
+module.exports.Real = Real;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bplist-creator",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Binary Mac OS X Plist (property list) creator.",
   "main": "bplistCreator.js",
   "scripts": {


### PR DESCRIPTION
The additions to the readme sums it up pretty well.

I did this because I needed to write `<real>1</real>` instead of `<integer>1</integer>`.
