### PR TITLE
Add compatibility with browserify Buffer

### DIFF
--- a/bplistCreator.js
+++ b/bplistCreator.js
@@ -3,6 +3,7 @@
 // adapted from http://code.google.com/p/plist/source/browse/trunk/src/main/java/com/dd/plist/BinaryPropertyListWriter.java
 
 var streamBuffers = require("stream-buffers");
+var isBuffer = require("is-buffer");
 
 var debug = false;
 
@@ -319,7 +320,7 @@ function toEntries(dicts) {
 
   if (dicts instanceof Array) {
     return toEntriesArray(dicts);
-  } else if (dicts instanceof Buffer) {
+  } else if (isBuffer(dicts)) {
     return [
       {
         type: 'data',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "bplist-parser": "~0.1.0",
+    "is-buffer": "1.1.4",
     "nodeunit": "0.9.1"
   },
   "dependencies": {


### PR DESCRIPTION
Use `is-buffer` module instead of directly doing `instanceof Buffer` for broader compatibility.