### PR TITLE
Translate BigInts into 32 bit numbers

### DIFF
--- a/bplistCreator.js
+++ b/bplistCreator.js
@@ -296,7 +296,7 @@ module.exports = function(dicts) {
     // write low-order bytes big-endian style
     var buf = new Buffer(bytes);
     var z = 0;
-    
+
     // javascript doesn't handle large numbers
     if(!is_signedint) {
       while (bytes > 4) {
@@ -374,6 +374,13 @@ function toEntries(dicts) {
       {
         type: 'boolean',
         value: dicts
+      }
+    ];
+  } else if (typeof(dicts) === 'bigint') {
+    return [
+      {
+        type: 'number',
+        value: BigInt.asIntN(32, dicts)
       }
     ];
   } else {

--- a/bplistCreator.js
+++ b/bplistCreator.js
@@ -380,7 +380,7 @@ function toEntries(dicts) {
     return [
       {
         type: 'number',
-        value: BigInt.asIntN(32, dicts)
+        value: Number(BigInt.asIntN(32, dicts))
       }
     ];
   } else {


### PR DESCRIPTION
On Node 10.4.0+ there is the possibility that the number is a [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt). Add support for that possibility.

In my testing the numbers that plists support are 32bit signed integers, so this translates the bigint to that.